### PR TITLE
Support for deleting a post

### DIFF
--- a/json_server.py
+++ b/json_server.py
@@ -4,7 +4,13 @@ from request_handler import HandleRequests, status
 from views import create_user, login_user, get_user_by_id
 from views import get_categories, create_category
 from views import get_tags, create_tag
-from views import create_post, get_posts, get_post_by_id, get_posts_by_user_id
+from views import (
+    create_post,
+    get_posts,
+    get_post_by_id,
+    get_posts_by_user_id,
+    delete_post,
+)
 
 
 class JSONServer(HandleRequests):
@@ -115,6 +121,20 @@ class JSONServer(HandleRequests):
                 return self.response(
                     "", status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value
                 )
+
+    def do_DELETE(self):
+        url = self.parse_url(self.path)
+
+        if url["requested_resource"] == "posts":
+            response = delete_post(url["pk"])
+            if response:
+                return self.response("", status.HTTP_204_SUCCESS_NO_RESPONSE_BODY.value)
+            else:
+                return self.response(
+                    "", status.HTTP_400_CLIENT_ERROR_BAD_REQUEST_DATA.value
+                )
+        else:
+            pass
 
 
 def main():

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -1,4 +1,10 @@
 from .user import login_user, create_user, get_user_by_id
 from .category import get_categories, create_category
 from .tag import get_tags, create_tag
-from .post import create_post, get_posts, get_post_by_id, get_posts_by_user_id
+from .post import (
+    create_post,
+    get_posts,
+    get_post_by_id,
+    get_posts_by_user_id,
+    delete_post,
+)

--- a/views/post.py
+++ b/views/post.py
@@ -205,3 +205,18 @@ def get_post_by_id(pk):
             return serialized_post
         else:
             return None
+
+
+def delete_post(pk):
+    with sqlite3.connect("./db.sqlite3") as conn:
+        conn.row_factory = sqlite3.Row
+        db_cursor = conn.cursor()
+
+        db_cursor.execute(
+            """
+            DELETE FROM Posts
+            WHERE id = ?
+            """,
+            (pk,),
+        )
+    return True


### PR DESCRIPTION
## What? ❓
Added support for client sending a delete a post request
## Why? 🧐
This allows posts to be deleted from the database when the client sends the appropriate request
## How? 🛠️
added a new method to the `JSONServer` class allowing `do_GET` to be used.
## Testing? ✅
Use the client to send a delete request and see it has been removed from the database.

